### PR TITLE
Fix StackOverflow URL

### DIFF
--- a/guidelines.html
+++ b/guidelines.html
@@ -189,10 +189,10 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td style="min-width: 83px"><a href="//stackoverflow.com/tagged/azure"><img 
+                            <td style="min-width: 83px"><a href="//stackoverflow.com/questions/tagged/azure"><img 
                                 src="azure/stackoverflow.png" alt="StackOverflow" title="StackOverflow" style="width: 83px;height: 82px" /></a></td>
-                            <td><a href="//stackoverflow.com/tagged/azure"><h2>StackOverflow</h2></a></td>
-                            <td><a href="//stackoverflow.com/tagged/azure">azure</a></td>
+                            <td><a href="//stackoverflow.com/questions/tagged/azure"><h2>StackOverflow</h2></a></td>
+                            <td><a href="//stackoverflow.com/questions/tagged/azure">azure</a></td>
                             <td>A friendly, open and fun community of developers.</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Fix the StackOverflow URL ("azure" tag), which was wrong and resulted in a 404 error ("questions/" was missing from the URL).
